### PR TITLE
Require the main source of the package, if defined.

### DIFF
--- a/bin/require-self
+++ b/bin/require-self
@@ -8,9 +8,14 @@ var cwd = process.cwd();
 var pkg = require(path.join(cwd, 'package.json'));
 var name = pkg.name;
 
+// If the package.json defines a main entry point, use that instead
+// of just plain '..'.
+var main = pkg.main;
+var mainPath = main ? path.join('..', main).split('\\').join('/') : '..';
+
 // Compute the location and content for the pseudo-module.
 var modulePath = path.join(cwd, 'node_modules', name + '.js');
-var moduleText = "module.exports = require('..');";
+var moduleText = "module.exports = require('" + mainPath + "');";
 
 // Create the pseudo-module.
 fs.writeFileSync(modulePath, moduleText);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "require-self",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Enable doing require('foobar') from within the foobar module",
   "keywords": ["require", "self", "module"],
   "bin": {


### PR DESCRIPTION
In my projects, I have no `index.js` in the root of the project. Rather, I am pointing npm to the _main entry point_ by way of the `"main"` definition in `package.json`. With the tools I am using, the trick of require-self only works if the auto-generated `.js` file in `node_modules` points at the right place.

I'd be thankful if you could include my modification in the _official release_, so I don't have to create yet another npm module just for my special use case ;-)
