### PR TITLE
Escape cwd so that it works for Windows as well

### DIFF
--- a/bin/require-self
+++ b/bin/require-self
@@ -10,7 +10,7 @@ var name = pkg.name;
 
 // Compute the location and content for the pseudo-module.
 var modulePath = path.join(cwd, 'node_modules', name + '.js');
-var moduleText = "module.exports = require('" + cwd + "');";
+var moduleText = "module.exports = require('" + cwd.replace(/\\/g, '\\\\') + "');";
 
 // Create the pseudo-module.
 try {


### PR DESCRIPTION
On windows, cwd contains the character `\`, so it must be escaped to `\\` for the path to work in a string.

before change:
```module.exports = require('C:\projects\my-project');```

after change:
```module.exports = require('C:\\projects\\my-project');```

change should not affect non-Windows platforms. as they use `/` as path separator.